### PR TITLE
Add compatibility for Python 3

### DIFF
--- a/pyipinfodb/pyipinfodb.py
+++ b/pyipinfodb/pyipinfodb.py
@@ -38,7 +38,7 @@ class IPInfo() :
         urlobj = urllib2.urlopen(url)
         data = urlobj.read()
         urlobj.close()
-        datadict = json.loads(data)
+        datadict = json.loads(data.decode('utf-8'))
         return datadict
 
     def get_country(self, ip=None):

--- a/pyipinfodb/pyipinfodb.py
+++ b/pyipinfodb/pyipinfodb.py
@@ -5,8 +5,14 @@
 """
 
 import json
-from urllib import urlencode
-import urllib2
+try:
+    from urllib import urlencode
+except ImportError:
+    from urllib.parse import urlencode
+try:
+    import urllib2
+except ImportError:
+    import urllib.request as urllib2
 import socket
 
 class IPInfo() :


### PR DESCRIPTION
This patch fixes some import errors experienced on Python 3.4.3 and loads the json as UTF-8 to be compatible with Python 3.

Tested and is working on Python 3.4.3 and Python 2.7.9.